### PR TITLE
Code Cov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
    
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,9 +20,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-   
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
@@ -56,11 +54,10 @@ jobs:
         output: file
         thresholds: '70 90'
     
-    - name: Add Coverage PR Comment
-      uses: marocchino/sticky-pull-request-comment@v2
-      if: github.event_name == 'pull_request'
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
       with:
-        recreate: true
-        path: code-coverage-results.md
-  
+        env_vars: OS,PYTHON
+        files: coverage.xml
+
 # TODO: seperate job for integration tests


### PR DESCRIPTION
This PR changes the code cov for the popular app version. Hopefully this version will work with Dependabot without the rigmarole of GA-based commenting actions. 

See: https://github.com/marocchino/sticky-pull-request-comment/issues/298