### PR TITLE
Remove type-hint from enter method

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tainers"
-version = "0.1.0"
+version = "0.1.1"
 description = "Simple replacement for testcontainers-python"
 authors = ["aperullo <18688190+aperullo@users.noreply.github.com>"]
 license = "MIT"

--- a/tainers/tainer.py
+++ b/tainers/tainer.py
@@ -109,7 +109,7 @@ class Tainer:
             volume (str): The volume to add to the container formatted as it would be to the docker command line. Like
                 anonymous volume: "/test"
                 bind-mount: "/test:/test"
-                nameed volume: "test:/test"
+                named volume: "test:/test"
 
         Returns:
             Tainer: the Tainer object
@@ -162,7 +162,7 @@ class Tainer:
         self._container.stop()
         self._container.remove(force=force, v=delete_volume)
 
-    def __enter__(self) -> "Tainer":
+    def __enter__(self):
         self.start()
         return self
 


### PR DESCRIPTION
Closes #6 

This PR removes the type-hinting from the `__enter__` method so that type engines like pyright can correctly derive the type to be returned from subclasses. It also fixes a typo.