### PR TITLE
Add pre/post start/stop phases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tainers"
-version = "0.2.0"
+version = "0.3.0"
 description = "Simple replacement for testcontainers-python"
 authors = ["aperullo <18688190+aperullo@users.noreply.github.com>"]
 license = "MIT"

--- a/tainers/tainer.py
+++ b/tainers/tainer.py
@@ -127,10 +127,18 @@ class Tainer:
         """
         return docker.from_env()
 
+    def pre_start(self):
+        """
+        A hook to be called before the container is started. This can be overriden in subclasses
+        """
+        pass
+
     def start(self):
         """
         Start the container using the args provided using the "with_" functions
         """
+        self.pre_start()
+
         client = self.docker_client
         try:
             client.images.get(self.image)
@@ -157,10 +165,31 @@ class Tainer:
             time.sleep(1)
 
         log.info("Container started as {}", self._container_id)
+        self.post_start()
+
+    def post_start(self):
+        """
+        A hook to be called after the container is started. This can be overriden in subclasses
+        """
+        pass
+
+    def pre_stop(self):
+        """
+        A hook to be called before the container is stopped. This can be overriden in subclasses
+        """
+        pass
 
     def stop(self, force=True, delete_volume=True):
+        self.pre_stop()
         self._container.stop()
         self._container.remove(force=force, v=delete_volume)
+        self.post_stop()
+
+    def post_stop(self):
+        """
+        A hook to be called after the container is stopped. This can be overriden in subclasses
+        """
+        pass
 
     def __enter__(self):
         self.start()

--- a/tests/unit/test_tainer.py
+++ b/tests/unit/test_tainer.py
@@ -73,6 +73,20 @@ def test_start():
         )
 
 
+def test_start_hooks():
+    with patch("tainers.tainer.Tainer.docker_client") as mocker, patch(
+        "tainers.tainer.Tainer.is_ready", return_value=True
+    ) as is_ready:
+
+        tainer = Tainer("image")
+        tainer.pre_start = MagicMock()
+        tainer.post_start = MagicMock()
+        tainer.start()
+
+        tainer.pre_start.assert_called()
+        tainer.post_start.assert_called()
+
+
 def test_stop():
     with patch("tainers.tainer.Tainer._container", return_value=MagicMock()):
         tainer = Tainer("image")
@@ -80,6 +94,17 @@ def test_stop():
 
         tainer._container.stop.assert_called_with()
         tainer._container.remove.assert_called_with(force=True, v=True)
+
+
+def test_stop_hooks():
+    with patch("tainers.tainer.Tainer._container", return_value=MagicMock()):
+        tainer = Tainer("image")
+        tainer.pre_stop = MagicMock()
+        tainer.post_stop = MagicMock()
+        tainer.stop()
+
+        tainer.pre_stop.assert_called()
+        tainer.post_stop.assert_called()
 
 
 def test_context_manager():


### PR DESCRIPTION
Closes #38 

**Description** 

This PR adds 4 new methods that implementers can override to customize their container startup and shutdown steps. These methods  are `pre_start`, `post_start`, `pre_stop`, and `post_stop`.

**Type of changes**
 <!--- Check all that apply --->

- [ ] Bug fix 
- [x] New feature
- [ ] Breaking change
- [ ] Documentation changes
- [ ] Github actions/repo changes

**Checklist**

- [x] Code formatted with black
- [x] Code comments explain why something is being done, not *what* is being done
- [x] Changed the documentation where needed
- [x] Added tests that prove fix is effective or that the feature works
- [x] All tests pass
- [x] Bumped poetry version 

<!--- NOTE: minor or patch version only. 1.0.0 is reserved for when 'Tainers are reached more maturity --->
