### PR TITLE
fix release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install poetry
       run: |
         curl -sSL \
-          "https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py" | python
+          "https://install.python-poetry.org" | python -
         # Adding `poetry` to `$PATH`:
         echo "$HOME/.poetry/bin" >> $GITHUB_PATH
     


### PR DESCRIPTION
**Description** 

 This PR fixes the url that poetry is downloaded from in the release job

**Type of changes**
 <!--- Check all that apply --->

- [ ] Bug fix 
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation changes
- [x] Github actions/repo changes

**Checklist**

- [ ] Code formatted with black
- [ ] Code comments explain why something is being done, not *what* is being done
- [ ] Changed the documentation where needed
- [ ] Added tests that prove fix is effective or that the feature works
- [ ] All tests pass
- [ ] Bumped poetry version 

<!--- NOTE: minor or patch version only. 1.0.0 is reserved for when 'Tainers are reached more maturity --->
